### PR TITLE
Reading XML definiton files

### DIFF
--- a/dlg/dlgattributes.cpp
+++ b/dlg/dlgattributes.cpp
@@ -135,11 +135,13 @@ void DlgAttributes::setDomElement( const QDomElement& roInElement )
       // fill attributes into the table widget
       for ( iCol = 0; iCol < 2; ++iCol )
       {
+        bool bCreated = false;
         // item in table
         QTableWidgetItem* poItem = mpoTableWidget->item( iRow, iCol );
         if ( !poItem )
         {
           poItem = new QTableWidgetItem;
+          bCreated = true;
         }
 
         if ( iCol == 0 )
@@ -154,7 +156,7 @@ void DlgAttributes::setDomElement( const QDomElement& roInElement )
         {
           poItem->setText( oAttribute.value() );
         }
-        mpoTableWidget->setItem( iRow, iCol, poItem);
+        if(bCreated)mpoTableWidget->setItem( iRow, iCol, poItem);
       }
     }
   }

--- a/elements/fsmelementbase.cpp
+++ b/elements/fsmelementbase.cpp
@@ -136,6 +136,12 @@ void FSMElementBase::applyAttributes( const QDomElement& /*roInElement*/ )
 
 }
 
+// apply attributes
+void FSMElementBase::applySceneAttributes( const QDomElement& /*roInElement*/ )
+{
+
+}
+
 // returns string list with definition names
 const QStringList FSMElementBase::getElementNames( void )
 {

--- a/elements/fsmelementbase.h
+++ b/elements/fsmelementbase.h
@@ -44,6 +44,7 @@ public:
 
     // apply attributes
     void applyAttributes( const QDomElement& roInElement );
+    void applySceneAttributes( const QDomElement& roInElement );
 
     // returns string list with definition names
     static const QStringList getElementNames( void );

--- a/elements/fsmelementifc.h
+++ b/elements/fsmelementifc.h
@@ -56,6 +56,7 @@ public:
 
     // apply attributes
     virtual void applyAttributes( const QDomElement& roInElement ) = 0;
+    virtual void applySceneAttributes( const QDomElement& roInElement ) = 0;
     // assign id of element containing related dom parent
     virtual void setDomParentId( const QString& roInId ) = 0;
 

--- a/elements/link.cpp
+++ b/elements/link.cpp
@@ -51,8 +51,6 @@ Link::Link(Node *poInFromNode, Node *poInToNode, bool bInDirected, bool bInProto
     return;
   }
 
-  mpoTextItem = new QGraphicsSimpleTextItem( this );
-
   // assign start node
   if ( poInFromNode ) moStateFrom = poInFromNode->getId();
   // assign end node
@@ -61,8 +59,15 @@ Link::Link(Node *poInFromNode, Node *poInToNode, bool bInDirected, bool bInProto
   mpoFromPort = poInFromNode->createConnectionPort( poInToNode );
   mpoToPort   = poInToNode->createConnectionPort( poInFromNode );
 
+  if ( !mpoFromPort || !mpoToPort)
+  {/// destination or source node do not exist
+    return;
+  }
+
   mpoFromPort->addLink(this);
   mpoToPort->addLink(this);
+
+  mpoTextItem = new QGraphicsSimpleTextItem( this );
 
   setFlags(QGraphicsItem::ItemIsSelectable);
   setZValue(-1);
@@ -312,10 +317,12 @@ void Link::paint
   if ( mbDrawArrow )
   {// draw arrow at end point
     QLineF oLineBack;
-    oLineBack.setP1(path().pointAtPercent(0));
+    //oLineBack.setP1(path().pointAtPercent(0));
+    oLineBack.setP1(path().pointAtPercent(1));
     oLineBack.setLength( ARROWSIZE );
     // rotate 15 degrees clockwise
-    oLineBack.setAngle( path().angleAtPercent(0) + 15.0 );
+//    oLineBack.setAngle( path().angleAtPercent(0) + 15.0 );
+    oLineBack.setAngle( path().angleAtPercent(1) + 195 );
 
     QPointF oArrowStart = oLineBack.p2();
     // rotate 2*15 degrees counter clockwise
@@ -339,6 +346,7 @@ void Link::updateText()
   if ( !mpoTextItem ) return;
 
   QString oText = moTrigger;
+
   if ( !moCondition.isEmpty())
   {
     oText +=" [";

--- a/elements/link.cpp
+++ b/elements/link.cpp
@@ -581,6 +581,91 @@ void Link::applyAttributes( const QDomElement& roInElement )
   }
 }
 
+
+// apply attributes
+void Link::applySceneAttributes( const QDomElement& roInElement )
+{
+
+  if ( !mpoFromPort || !mpoToPort ) return;
+
+  QString oPolygon = roInElement.attribute( gmaAttributeNames[ AN_POLYGON], "");
+  if ( !oPolygon.isEmpty() )
+  {
+    QStringList oPointList = oPolygon.split(" ");
+    if ( mpoFromPort && oPointList.count() >= 2 )
+    {
+      bool bValid = false;
+      double dX = (oPointList.takeFirst()).toDouble( &bValid );
+      if ( bValid )
+      {
+        double dY = (oPointList.takeFirst()).toDouble( &bValid );
+        if ( bValid )
+        {
+
+          mpoFromPort->setPos( dX, dY );
+          mpoFromPort->update();
+        }
+        else
+        {
+          assert( 0 );
+        }
+      }
+      else
+      {
+        assert( 0 );
+      }
+    }
+
+    if ( mpoToPort && oPointList.count() >= 2 )
+    {
+      bool bValid = false;
+      double dX = (oPointList.takeFirst()).toDouble( &bValid );
+      if ( bValid )
+      {
+        double dY = (oPointList.takeFirst()).toDouble( &bValid );
+        if ( bValid )
+        {
+          mpoToPort->setPos( dX, dY );
+          mpoToPort->update();
+        }
+        else
+        {
+          assert( 0 );
+        }
+      }
+      else
+      {
+        assert( 0 );
+      }
+    }
+
+    if( oPointList.count() >= 2 )
+    {
+      bool bValid = false;
+      double dX = (oPointList.takeFirst()).toDouble( &bValid );
+      if ( bValid )
+      {
+        double dY = (oPointList.takeFirst()).toDouble( &bValid );
+        if ( bValid )
+        {
+          moControlPoint.setX(dX);
+          moControlPoint.setY(dY);
+        }
+        else
+        {
+          assert( 0 );
+        }
+      }
+      else
+      {
+        assert( 0 );
+      }
+    }
+  }
+  updateGeometry();
+}
+
+
 // slot to connect on signal sigChangedId( const FSMElementIfc&)
 void Link::slotUpdateId( const FSMElementIfc& )
 {

--- a/elements/link.h
+++ b/elements/link.h
@@ -62,6 +62,7 @@ public:
     bool setAttribute( const QString& roInName, const QString& roInValue);
     // apply attributes
     void applyAttributes( const QDomElement& roInElement );
+    void applySceneAttributes( const QDomElement& roInElement );
 
 protected:
     // calculate id from a dom element

--- a/elements/node.cpp
+++ b/elements/node.cpp
@@ -352,7 +352,7 @@ void Node::paint(QPainter *painter,
     QRectF oExitRect = getExitSectionRect();
     qreal height1=getNameRect().height() + mdPadding;
     qreal height2=height1 + getEnterSectionRect().height();
-  //  qreal height3=height2 + getExitSectionRect().height();
+    qreal height3=height2 + getExitSectionRect().height();
     painter->drawText(QRectF(oRect.left(),oRect.top(),oRect.width(),height1), Qt::AlignCenter, oText.trimmed() );
     painter->setPen(penSections);
     painter->drawLine(QPointF(oRect.left(),oRect.top() + height1),QPoint(oRect.right(),oRect.top() + height1));
@@ -374,8 +374,8 @@ void Node::paint(QPainter *painter,
     oText += getExitEventsStr();
 
     painter->drawText(QRectF(oRect.left(),oRect.top() + height2,oRect.width(),getExitSectionRect().height()), Qt::AlignCenter, oText.trimmed() );
-//    painter->setPen(penSections);
-//    painter->drawLine(QPointF(oRect.left(),oRect.top() + height3),QPoint(oRect.right(),oRect.top() + height3));
+   // painter->setPen(penSections);
+   // painter->drawLine(QPointF(oRect.left(),oRect.top() + height3),QPoint(oRect.right(),oRect.top() + height3));
   }
   else
   {
@@ -649,28 +649,6 @@ void Node::applyAttributes( const QDomElement& roInElement )
   oAttr  = roInElement.attribute( gmaAttributeNames[ AN_EVENTEXIT], "");
   moExitEvents = oAttr;
 
-  // x
-  oAttr = roInElement.attribute( gmaAttributeNames[ AN_X], "");
-  if ( !oAttr.isEmpty())
-  {
-    setX( oAttr.toDouble());
-  }
-  // y
-  oAttr = roInElement.attribute( gmaAttributeNames[ AN_Y], "");
-  if ( !oAttr.isEmpty())
-  {
-    setY( oAttr.toDouble());
-  }
-
-#if 0
-  // width
-  oAttr = roInElement.attribute( gmaAttributeNames[ AN_WIDTH], "");
-  if ( !oAttr.isEmpty()) ( oAttr.toDouble());
-  // height
-  oAttr = roInElement.attribute( gmaAttributeNames[ AN_HEIGHT], "");
-  if ( !oAttr.isEmpty()) ( oAttr.toDouble());
-#endif
-
   // add reference
   const QDomNode& roDomNode = roInElement.parentNode();
   if ( !roDomNode.isNull() )
@@ -693,6 +671,33 @@ void Node::applyAttributes( const QDomElement& roInElement )
     }
   }
 }
+
+
+void Node::applySceneAttributes( const QDomElement& roInElement )
+{
+  // x
+  QString oAttr = roInElement.attribute( gmaAttributeNames[ AN_X], "");
+  if ( !oAttr.isEmpty())
+  {
+    setX( oAttr.toDouble());
+  }
+  // y
+  oAttr = roInElement.attribute( gmaAttributeNames[ AN_Y], "");
+  if ( !oAttr.isEmpty())
+  {
+    setY( oAttr.toDouble());
+  }
+
+#if 0
+  // width
+  oAttr = roInElement.attribute( gmaAttributeNames[ AN_WIDTH], "");
+  if ( !oAttr.isEmpty()) ( oAttr.toDouble());
+  // height
+  oAttr = roInElement.attribute( gmaAttributeNames[ AN_HEIGHT], "");
+  if ( !oAttr.isEmpty()) ( oAttr.toDouble());
+#endif
+}
+
 
 // create selection handles
 void Node::createSelectionHandles()

--- a/elements/node.h
+++ b/elements/node.h
@@ -40,8 +40,6 @@ public:
         , AN_Y           /// y coordinate
         , AN_WIDTH       /// width
         , AN_HEIGHT      /// heigth
-        , AN_ENTERPORT_X /// state entry port x
-        , AN_ENTERPORT_Y /// state entry port y
         , AN_LAST        /// end marker
     };
 
@@ -61,6 +59,8 @@ public:
     QColor outlineColor() const;
     void setBackgroundColor(const QColor &roInolor);
     QColor backgroundColor() const;
+
+    int portCnt() const { return miPortCnt; }
 
     /* overwritten methods of base class */
     QRectF boundingRect() const;
@@ -144,7 +144,6 @@ protected:
     QColor moOutlineColor;
 
     static const qreal   gmdLimitMaxWidth; /// maximum text width
-    Port*  mpoEnterPort;
 
 
 

--- a/elements/node.h
+++ b/elements/node.h
@@ -91,6 +91,7 @@ public:
     bool setAttribute( const QString& roInName, const QString& roInValue);
     // apply attributes
     void applyAttributes( const QDomElement& roInElement );
+    void applySceneAttributes( const QDomElement& roInElement );
 
 #if 0
     // calculate id by Element class using related Dom Element

--- a/fsmelementmanager.cpp
+++ b/fsmelementmanager.cpp
@@ -253,7 +253,7 @@ void FSMElementManager::addTreeItem( FSMDefinitionIfc* poInDefinition )
   {// secion missing
     mpoRootTreeItemDefinitions =
         new QTreeWidgetItem( mpoMainWindow->getDefinitionView());
-    mpoRootTreeItemDefinitions->setText( 0, moRootName );
+    mpoRootTreeItemDefinitions->setText( 0, "definitions" );
   }
   // create new item
   QTreeWidgetItem* poTreeItem =
@@ -537,7 +537,7 @@ bool FSMElementManager::parseSceneElement( const QDomElement& roInElement)
         FSMElementIfc* poItem = getItem( oId );
         if ( poItem )
         {// assgingn values contained in attributes
-          poItem->applyAttributes( oSceneElement );
+          poItem->applySceneAttributes( oSceneElement );
         }
       } // attribut id is assigned
       oSceneElement = oSceneElement.nextSiblingElement(gmaXMLSectionNames[ eElementType ]);

--- a/mainwin.cpp
+++ b/mainwin.cpp
@@ -48,6 +48,7 @@ MainWin::MainWin()
   , mpoStateNav( 0 )
   , mpoDlgAttributes( 0 )
   , mpoDlgDefinitionNew( 0 )
+  , mpoSelectedNode(0)
 {
   mpoView->setScene(mpoScene);
   mpoView->setDragMode(QGraphicsView::RubberBandDrag);
@@ -146,6 +147,9 @@ void MainWin::slotAddNode( const QDomElement * poInElement )
 
   setupNode(poNode);
 }
+
+
+
 
 void MainWin::slotAddLink( const QDomElement * poInElement )
 {
@@ -536,12 +540,34 @@ void MainWin::setupNode(Node *poInNode)
   slotBringToFront();
 }
 
-Node *MainWin::selectedNode() const
+void MainWin::setupEnter(Node *poInNode)
+{
+  poInNode->setPos(QPoint(80 + (100 * (miNumber % 5)),
+                          80 + (50 * ((miNumber / 5) % 7))));
+  mpoScene->addItem(poInNode);
+  ++miNumber;
+
+  mpoScene->clearSelection();
+  poInNode->setSelected(true);
+  slotBringToFront();
+}
+
+
+
+Node *MainWin::selectedNode()
 {
   QList<QGraphicsItem *> items = mpoScene->selectedItems();
   if (items.count() == 1) {
+    mpoSelectedNode = dynamic_cast<Node *>(items.first());
     return dynamic_cast<Node *>(items.first());
-  } else {
+  }
+  else if(items.isEmpty())
+  {
+    mpoSelectedNode = 0;
+    return 0;
+  }
+  else
+  {
     return 0;
   }
 }
@@ -563,7 +589,17 @@ MainWin::NodePair_T MainWin::selectedNodePair() const
     Node *first = dynamic_cast<Node *>(items.first());
     Node *second = dynamic_cast<Node *>(items.last());
     if (first && second)
-      return NodePair_T(first, second);
+    {
+      if( (0 != mpoSelectedNode) && (second == mpoSelectedNode) )
+      {
+        qDebug() << "changed order";
+        return NodePair_T(second,first);
+      }
+      else
+      {
+        return NodePair_T(first, second);
+      }
+    }
   }
   return NodePair_T();
 }

--- a/mainwin.h
+++ b/mainwin.h
@@ -65,7 +65,8 @@ private:
   void createNavigation();
   void setZValue(int z);
   void setupNode(Node *node);
-  Node *selectedNode() const;
+  void setupEnter(Node *node);
+  Node *selectedNode();
   Link *selectedLink() const;
   NodePair_T selectedNodePair() const;
 
@@ -78,6 +79,7 @@ private:
   QAction *mpoActionClose;
   QAction *mpoActionExit;
   QAction *mpoActionNode;
+  QAction *mpoActionEntryNode;
   QAction *mpoActionLink;
   QAction *mpoActionDefinition;
   QAction *mpoActionDelete;
@@ -98,6 +100,7 @@ private:
   QTreeWidget*     mpoStateNav;          // state navigation
   DlgAttributes*   mpoDlgAttributes;     // Dialog to show dom attributes
   DlgDefinitionNew* mpoDlgDefinitionNew; // dialog for new definition
+  Node* mpoSelectedNode;
 
   int miMinZ;
   int miMaxZ;


### PR DESCRIPTION
Hi!

Reading of xml files with scene tags destroyed the fsm display completly, cause the same method was used to parse element tags for fsm and scene definitions. E.g. the scene definition has no type element, so the type element was overwritten empty etc.

Solution: Apply scene attributes with different method
